### PR TITLE
Fix deployments returning successful before they have resolved

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,8 @@
         "mocha": true
     },
     "plugins": [
-      "eslint-plugin-prettier"
+      "eslint-plugin-prettier",
+      "mocha"
     ],
     "extends": "airbnb-base",
     "globals": {

--- a/lib/OpenShiftClientResult.js
+++ b/lib/OpenShiftClientResult.js
@@ -19,13 +19,93 @@
 'use strict';
 
 // const OpenShiftClient = require('./OpenShiftClient');
+const isEmpty = require('lodash.isempty');
 
 module.exports = class OpenShiftClientResult {
-  /**
-   *
-   * @param {OpenShiftClient} client
-   */
   constructor(client) {
     this.client = client;
+  }
+
+  /**
+   * parses the string output from an oc get object --watch command
+   * this function in particular returns the field names as identified from the initial
+   * output from ocp
+   */
+  static parseGetObjectFields(stdOut) {
+    const [fieldNames] = stdOut.split('\n');
+
+    const names = fieldNames.replace(/ {2,}/g, '|{}|').split('|{}|');
+
+    return names.map((n) => {
+      return n.toLowerCase().replace(/ +/g, '_');
+    });
+  }
+
+  /**
+   * parses the string output from an oc get object --watch command
+   * this function in particular returns the data values from subsequent returns from ocp
+   */
+  static parseGetObjectValues(stdOut) {
+    const entries = stdOut
+      .trim()
+      .replace(/ {2,}/g, '|{}|')
+      .split('|{}|');
+    return entries;
+  }
+
+  /**
+   * waits for a deployment from the oc get dc --wait command
+   * it will kill the process once the desired replicas and current replicas are equal
+   * @param {Process} proc the process command that was spawned for oc get blah
+   *
+   * usage:
+   * const proc = self.rawAsync('get', 'dc', {
+      selector: `app=${appName}`,
+      watch: 'true'
+     });
+
+     OpenshiftClientResult.waitForDeployment(proc);
+     // proc will kill when replicas match desired amount
+
+     proc.on('exit', () => do something here)
+   */
+  static waitForDeployment(proc) {
+    let deployment = {};
+    // eslint-disable-next-line no-console
+    console.log(`WAITING FOR DEPLOYMENT:
+      if a deployment fails, it will not throw. 
+      Ensure you are setting appropriate timeouts while using this implementation!
+    `);
+
+    proc.stdout.on('data', (data) => {
+      let stdOut = data.toString();
+      if (isEmpty(deployment)) {
+        const keys = OpenShiftClientResult.parseGetObjectFields(stdOut);
+        deployment = keys.reduce((obj, key) => {
+          // eslint-disable-next-line no-param-reassign
+          obj[key] = '';
+          return obj;
+        }, {});
+
+        // we need reference to keys to assign deployment values later
+        // eslint-disable-next-line no-underscore-dangle
+        deployment._keys = keys;
+
+        // the first stdout instance contains fields and values and so we remove field names now
+        // eslint-disable-next-line no-unused-vars
+        const [names, entries] = stdOut.split('\n');
+        stdOut = entries;
+      }
+
+      const deployData = OpenShiftClientResult.parseGetObjectValues(stdOut);
+      deployData.forEach((d, index) => {
+        // eslint-disable-next-line no-underscore-dangle
+        deployment[deployment._keys[index]] = d;
+      });
+
+      if (deployment.desired === deployment.current && deployment.desired !== '') {
+        proc.kill('SIGTERM');
+      }
+    });
   }
 };

--- a/lib/OpenShiftClientX.js
+++ b/lib/OpenShiftClientX.js
@@ -19,7 +19,6 @@
 'use strict';
 
 const { isArray } = Array;
-
 const info = require('debug')('info:OpenShiftClient');
 const trace = require('debug')('trace:OpenShiftClient');
 
@@ -27,6 +26,7 @@ const path = require('path');
 const isPlainObject = require('lodash.isplainobject');
 const fs = require('fs');
 const OpenShiftClient = require('./OpenShiftClient');
+const OpenShiftClientResult = require('./OpenShiftClientResult');
 const OpenShiftStaticSelector = require('./OpenShiftStaticSelector');
 const Transformers = require('./transformers');
 const isOpenShiftList = require('./isOpenShiftList');
@@ -35,7 +35,7 @@ const CONSTANTS = require('./constants');
 
 const logger = { info, trace };
 
-module.exports = class OpenShiftClientX extends OpenShiftClient {
+class OpenShiftClientX extends OpenShiftClient {
   constructor(options) {
     super(options);
     this.cache = new Map();
@@ -574,7 +574,6 @@ module.exports = class OpenShiftClientX extends OpenShiftClient {
   }
 
   async applyAndDeploy(resources, appName) {
-    // return async function (resources) {
     this.fetchSecretsAndConfigMaps(resources);
     // TODO: When there is an HorizontalPodAutoscaler,
     //   we need to update the dc.replicas to match hpa.status.desiredReplicas (existing)
@@ -584,76 +583,29 @@ module.exports = class OpenShiftClientX extends OpenShiftClient {
       output: 'jsonpath={range .items[*]}{.metadata.name}{"\\t"}{.spec.replicas}{"\\t"}{.status.latestVersion}{"\\n"}{end}' // eslint-disable-line prettier/prettier
     });
     //
-    this.apply(resources);
+    this.apply(resources, { wait: true });
 
     const newDCs = this.raw('get', ['dc'], {
       selector: `app=${appName}`,
       output: 'jsonpath={range .items[*]}{.metadata.name}{"\\t"}{.spec.replicas}{"\\t"}{.status.latestVersion}{"\\n"}{end}' // eslint-disable-line prettier/prettier
     });
-    const self = this;
 
-    // if (existingDC.stdout !== newDCs.stdout) {
-    return new Promise(async (resolve) => {
-      if (existingDC.stdout !== newDCs.stdout) {
-        const pending = new Map();
-        for (let i = 0; i < resources.length; i += 1) {
-          const resource = resources[i];
-          if (resource.kind === CONSTANTS.KINDS.DEPLOYMENT_CONFIG) {
-            pending.set(resource.metadata.name, true);
-          }
-        }
-        logger.trace(`watching ... ${pending.keys()}`);
-        const proc = self.rawAsync('get', 'dc', {
-          selector: `app=${appName}`,
-          watch: 'true',
-          output: 'jsonpath={.metadata.name}{"\\t"}{.status.replicas}{"\\t"}{.status.availableReplicas}{"\\t"}{.status.unavailableReplicas}{"\\t"}{.status.latestVersion}{"\\n"}' // eslint-disable-line prettier/prettier
-        });
-        let stdout = '';
-        // TODO: NEEDS a timeout!!!
-        proc.stdout.on('data', (data) => {
-          stdout += data;
-          let i = -1;
-          // eslint-disable-next-line no-cond-assign
-          while ((i = stdout.indexOf('\n')) >= 0) {
-            // let line = stdout.substring(0, i).replace(/(\s)+/g, "\t").trim();
-            stdout = stdout.substr(i + 1);
-            // logger.trace(`Processing '${line}'`)
-            const status = self.raw('get', ['dc'], {
-              selector: `app=${appName}`,
-              'no-headers': 'true',
-              output: 'custom-columns=NAME:.metadata.name,DESIRED:.spec.replicas,CURRENT:.status.replicas,AVAILABLE:.status.availableReplicas,UNAVAILABLE:.status.unavailableReplicas,VERSION:.status.latestVersion' // eslint-disable-line prettier/prettier
-            });
-            const lines = status.stdout.trim().split('\n');
-            lines.forEach((line) => {
-              // logger.trace(`Processing line: '${line}'`)
-              const columns = line.split(/\s+/);
-              // logger.trace(`Processing columns: '${columns}'`)
-              if (columns[1] === columns[3]) {
-                pending.delete(columns[0]);
-              } else {
-                logger.info(`Waiting for ${columns[0]} (${columns[3]}/${columns[1]})`);
-              }
-            });
-          }
-
-          if (pending.size === 0) {
-            // console.log(`Nothing else to process`)
-            proc.kill('SIGTERM');
-          }
-        });
-
-        proc.stderr.on('data', async (data) => {
-          // eslint-disable-next-line no-console
-          console.log(`stderr:${data}`);
-        });
-
-        proc.on('exit', () => {
-          resolve(resources);
-        });
-      } else {
-        resolve(resources);
-      }
+    const proc = this.rawAsync('get', 'dc', {
+      selector: `app=${appName}`,
+      watch: 'true'
     });
-    // } // if
+
+    return new Promise((resolve) => {
+      if (existingDC.stdout !== newDCs.stdout) {
+        OpenShiftClientResult.waitForDeployment(proc);
+      } else {
+        proc.kill('SIGTERM');
+      }
+      proc.on('exit', () => {
+        return resolve();
+      });
+    });
   }
-};
+}
+
+module.exports = OpenShiftClientX;

--- a/lib/OpenShiftClientX.js
+++ b/lib/OpenShiftClientX.js
@@ -583,7 +583,7 @@ class OpenShiftClientX extends OpenShiftClient {
       output: 'jsonpath={range .items[*]}{.metadata.name}{"\\t"}{.spec.replicas}{"\\t"}{.status.latestVersion}{"\\n"}{end}' // eslint-disable-line prettier/prettier
     });
     //
-    this.apply(resources, { wait: true });
+    this.apply(resources);
 
     const newDCs = this.raw('get', ['dc'], {
       selector: `app=${appName}`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2249,6 +2249,11 @@
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
+    "lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
+    },
     "lodash.isfunction": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
@@ -2312,6 +2317,11 @@
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
+    },
+    "map-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
+      "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g=="
     },
     "map-visit": {
       "version": "1.0.0",
@@ -2668,7 +2678,7 @@
         },
         "find-up": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
@@ -2683,7 +2693,7 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
@@ -2702,7 +2712,7 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
@@ -2754,7 +2764,7 @@
         },
         "y18n": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "dev": true
         },
@@ -3472,6 +3482,15 @@
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
+    "snakecase-keys": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-3.1.0.tgz",
+      "integrity": "sha512-QM038drLbhdOY5HcRQVjO1ZJ1WR7yV5D5TIBzcOB/g3f5HURHhfpYEnvOyzXet8K+MQsgeIUA7O7vn90nAX6EA==",
+      "requires": {
+        "map-obj": "^4.0.0",
+        "to-snake-case": "^1.0.0"
+      }
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -3956,6 +3975,11 @@
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
+    "to-no-case": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-1.0.2.tgz",
+      "integrity": "sha1-xyKQcWTvaxeBMsjmmTAhLRtKoWo="
+    },
     "to-object-path": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
@@ -3996,6 +4020,22 @@
       "requires": {
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
+      }
+    },
+    "to-snake-case": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-snake-case/-/to-snake-case-1.0.0.tgz",
+      "integrity": "sha1-znRpE4l5RgGah+Yu366upMYIq4w=",
+      "requires": {
+        "to-space-case": "^1.0.0"
+      }
+    },
+    "to-space-case": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-space-case/-/to-space-case-1.0.0.tgz",
+      "integrity": "sha1-sFLar7Gysp3HcM6gFj5ewOvJ/Bc=",
+      "requires": {
+        "to-no-case": "^1.0.0"
       }
     },
     "trim-right": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1061,6 +1061,15 @@
         }
       }
     },
+    "eslint-plugin-mocha": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-6.1.1.tgz",
+      "integrity": "sha512-p/otruG425jRYDa28HjbBYYXoFNzq3Qp++gn5dbE44Kz4NvmIsSUKSV1T+RLYUcZOcdJKKAftXbaqkHFqReKoA==",
+      "dev": true,
+      "requires": {
+        "ramda": "^0.26.1"
+      }
+    },
     "eslint-plugin-prettier": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.0.tgz",
@@ -3166,6 +3175,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "ramda": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
+      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
       "dev": true
     },
     "react": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
     "debug": "^4.1.0",
     "lodash.isfunction": "^3.0.9",
     "lodash.isplainobject": "^4.0.6",
-    "lodash.isstring": "^4.0.1"
+    "lodash.isstring": "^4.0.1",
+    "lodash.isempty": "^4.0.1",
+    "snakecase-keys": "^3.1.0"
   },
   "devDependencies": {
     "eslint": "^5.16.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "eslint-config-airbnb-base": "^13.2.0",
     "eslint-config-prettier": "^4.3.0",
     "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-mocha": "^6.1.1",
     "eslint-plugin-prettier": "^3.1.0",
     "expect": "^24.8.0",
     "mocha": "^5.2.0",

--- a/test/OpenShiftClientX.e2e.test.js
+++ b/test/OpenShiftClientX.e2e.test.js
@@ -22,35 +22,37 @@ const expect = require('expect');
 const OpenShiftClientX = require('../lib/OpenShiftClientX');
 const OpenShiftResourceSelector = require('../lib/OpenShiftResourceSelector');
 
-const PROJECT_TOOLS = 'csnr-devops-lab-tools'
-const PROJECT_DEPLOY = 'csnr-devops-lab-deploy'
+const PROJECT_TOOLS = 'csnr-devops-lab-tools';
+// const PROJECT_DEPLOY = 'csnr-devops-lab-deploy';
 
-describe.skip('OpenShiftClientX - @e2e', function() {
+describe.skip('OpenShiftClientX - @e2e', () => {
   this.timeout(999999);
-  const oc = new OpenShiftClientX({namespace:PROJECT_TOOLS})
+  const oc = new OpenShiftClientX({ namespace: PROJECT_TOOLS });
 
-  it('e2e - @e2e', function() {
-    var params={NAME:'my-test-app'}
+  it('e2e - @e2e', () => {
+    const params = { NAME: 'my-test-app' };
 
-    
-    var fileUrl = oc.toFileUrl(`${__dirname}/resources/bc.template.json`)
-    var processResult= oc.process(fileUrl,{param:params});
-    
-    oc.delete(oc.toNamesList(processResult), {'ignore-not-found':'true'})
+    const fileUrl = oc.toFileUrl(`${__dirname}/resources/bc.template.json`);
+    const processResult = oc.process(fileUrl, { param: params });
 
-    expect(processResult).toBeInstanceOf(Array)
-    expect(processResult).toHaveLength(4)
+    oc.delete(oc.toNamesList(processResult), { 'ignore-not-found': 'true' });
 
-    oc.applyBestPractices(oc.wrapOpenShiftList(processResult))
-    oc.applyRecommendedLabels(processResult, 'my-test-app', 'dev', '1')
-    oc.fetchSecretsAndConfigMaps(processResult)
+    expect(processResult).toBeInstanceOf(Array);
+    expect(processResult).toHaveLength(4);
 
-    var applyResult = oc.apply(processResult)
-    expect(applyResult).toBeInstanceOf(OpenShiftResourceSelector)
+    oc.applyBestPractices(oc.wrapOpenShiftList(processResult));
+    oc.applyRecommendedLabels(processResult, 'my-test-app', 'dev', '1');
+    oc.fetchSecretsAndConfigMaps(processResult);
 
-    expect(applyResult.names()).toEqual([`imagestream.image.openshift.io/${params.NAME}`, `imagestream.image.openshift.io/${params.NAME}-core`, `buildconfig.build.openshift.io/${params.NAME}-core`, `buildconfig.build.openshift.io/${params.NAME}`])
-    
-    applyResult.narrow('bc').startBuild({wait:'true'})
+    const applyResult = oc.apply(processResult);
+    expect(applyResult).toBeInstanceOf(OpenShiftResourceSelector);
 
-  }) //end it
-}) //end describe
+    expect(applyResult.names()).toEqual([
+      `imagestream.image.openshift.io/${params.NAME}`,
+      `imagestream.image.openshift.io/${params.NAME}-core`,
+      `buildconfig.build.openshift.io/${params.NAME}-core`,
+      `buildconfig.build.openshift.io/${params.NAME}`
+    ]);
+    applyResult.narrow('bc').startBuild({ wait: 'true' });
+  }); // end it
+}); // end describe

--- a/test/OpenShiftClientX.e2e.test.js
+++ b/test/OpenShiftClientX.e2e.test.js
@@ -26,10 +26,10 @@ const PROJECT_TOOLS = 'csnr-devops-lab-tools';
 // const PROJECT_DEPLOY = 'csnr-devops-lab-deploy';
 
 describe.skip('OpenShiftClientX - @e2e', () => {
-  this.timeout(999999);
+  // this.timeout(999999);
   const oc = new OpenShiftClientX({ namespace: PROJECT_TOOLS });
 
-  it('e2e - @e2e', () => {
+  it.skip('e2e - @e2e', () => {
     const params = { NAME: 'my-test-app' };
 
     const fileUrl = oc.toFileUrl(`${__dirname}/resources/bc.template.json`);

--- a/test/OpenShiftClientX.test.js
+++ b/test/OpenShiftClientX.test.js
@@ -150,7 +150,11 @@ describe('OpenShiftClientX', function() {
       )
       .returns({
         status: 0,
-        stdout: `imagestream.image.openshift.io/${params.NAME}-core\nimagestream.image.openshift.io/${params.NAME}\nbuildconfig.build.openshift.io/${params.NAME}-core\nbuildconfig.build.openshift.io/${params.NAME}`
+        stdout: `imagestream.image.openshift.io/${
+          params.NAME
+        }-core\nimagestream.image.openshift.io/${params.NAME}\nbuildconfig.build.openshift.io/${
+          params.NAME
+        }-core\nbuildconfig.build.openshift.io/${params.NAME}`
       });
 
     const filterByFullName = (fullNames) => {

--- a/test/OpenShiftClientX.test.js
+++ b/test/OpenShiftClientX.test.js
@@ -150,11 +150,7 @@ describe('OpenShiftClientX', function() {
       )
       .returns({
         status: 0,
-        stdout: `imagestream.image.openshift.io/${
-          params.NAME
-        }-core\nimagestream.image.openshift.io/${params.NAME}\nbuildconfig.build.openshift.io/${
-          params.NAME
-        }-core\nbuildconfig.build.openshift.io/${params.NAME}`
+        stdout: `imagestream.image.openshift.io/${params.NAME}-core\nimagestream.image.openshift.io/${params.NAME}\nbuildconfig.build.openshift.io/${params.NAME}-core\nbuildconfig.build.openshift.io/${params.NAME}`
       });
 
     const filterByFullName = (fullNames) => {

--- a/test/OpenShiftClientX.test.js
+++ b/test/OpenShiftClientX.test.js
@@ -150,11 +150,7 @@ describe('OpenShiftClientX', function() {
       )
       .returns({
         status: 0,
-        stdout: `imagestream.image.openshift.io/${
-          params.NAME
-        }-core\nimagestream.image.openshift.io/${params.NAME}\nbuildconfig.build.openshift.io/${
-          params.NAME
-        }-core\nbuildconfig.build.openshift.io/${params.NAME}`
+        stdout: `imagestream.image.openshift.io/${params.NAME}-core\nimagestream.image.openshift.io/${params.NAME}\nbuildconfig.build.openshift.io/${params.NAME}-core\nbuildconfig.build.openshift.io/${params.NAME}`
       });
 
     const filterByFullName = (fullNames) => {
@@ -614,7 +610,7 @@ describe('OpenShiftClientX', function() {
     // eslint-disable-next-line max-len
     // eslint-disable-next-line func-names, space-before-function-paren, prefer-arrow-callback, prettier/prettier, max-len
     stubActionAsync.withArgs(
-      ["--namespace=csnr-devops-lab-tools", "get", "dc", "--selector=app=my-test-app-0", "--watch=true", "--output=jsonpath={.metadata.name}{\"\\t\"}{.status.replicas}{\"\\t\"}{.status.availableReplicas}{\"\\t\"}{.status.unavailableReplicas}{\"\\t\"}{.status.latestVersion}{\"\\n\"}"] // eslint-disable-line prettier/prettier,quotes,max-len
+      ["--namespace=csnr-devops-lab-tools", "get", "dc", "--selector=app=my-test-app-0", "--watch=true"] // eslint-disable-line prettier/prettier,quotes,max-len
     ).returns(createProc()); // eslint-disable-line prettier/prettier,max-len
 
     // eslint-disable-next-line max-len


### PR DESCRIPTION
Deployments using the `applyAndDeploy` command resolves before deployments are finished. 

I Modified how deployment status is found.

This PR bases deployment status off of the `oc get dc/id --watch` flag. This process returns plain text which is parsed (I know I know). The comparison between different outputs is made. When current replicas match desired replicas, the process is killed.

> Failing Tests: I'm not sure what is causing the tests to fail 😢 

Fixes #16 