### PR TITLE
Use Go template instead of jsonpath

### DIFF
--- a/lib/OpenShiftClientX.js
+++ b/lib/OpenShiftClientX.js
@@ -579,14 +579,14 @@ class OpenShiftClientX extends OpenShiftClient {
     //   or hpa.spec.minReplicas (new)
     const existingDC = this.raw('get', ['dc'], {
       selector: `app=${appName}`,
-      output: 'jsonpath={range .items[*]}{.metadata.name}{"\\t"}{.spec.replicas}{"\\t"}{.status.latestVersion}{"\\n"}{end}' // eslint-disable-line prettier/prettier
+      output: 'template={{range .items}}{{.metadata.name}}{{.spec.replicas}}{{.status.latestVersion}} {{end}}' // eslint-disable-line prettier/prettier
     });
     //
     this.apply(resources);
 
     const newDCs = this.raw('get', ['dc'], {
       selector: `app=${appName}`,
-      output: 'jsonpath={range .items[*]}{.metadata.name}{"\\t"}{.spec.replicas}{"\\t"}{.status.latestVersion}{"\\n"}{end}' // eslint-disable-line prettier/prettier
+      output: 'template={{range .items}}{{.metadata.name}}{{.spec.replicas}}{{.status.latestVersion}} {{end}}' // eslint-disable-line prettier/prettier
     });
 
     const proc = this.rawAsync('get', 'dc', {

--- a/test/OpenShiftClientX.test.js
+++ b/test/OpenShiftClientX.test.js
@@ -538,7 +538,7 @@ describe('OpenShiftClientX', function() {
 
     // eslint-disable-next-line prettier/prettier
     stubAction.withArgs(
-      ['--namespace=csnr-devops-lab-tools', 'get', 'dc', '--selector=app=my-test-app-0', '--output=jsonpath={range .items[*]}{.metadata.name}{"\\t"}{.spec.replicas}{"\\t"}{.status.latestVersion}{"\\n"}{end}'] // eslint-disable-line prettier/prettier,max-len
+      ['--namespace=csnr-devops-lab-tools', 'get', 'dc', '--selector=app=my-test-app-0', '--output=template={{range .items}}{{.metadata.name}}{{.spec.replicas}}{{.status.latestVersion}} {{end}}'] // eslint-disable-line prettier/prettier,max-len
     ) // eslint-disable-line prettier/prettier,max-len,indent
     .onFirstCall().returns({ status: 0, stdout: 'my-test-app-0\t1\t1' }) // eslint-disable-line prettier/prettier,max-len,indent
     .returns({ status: 0, stdout: 'my-test-app-0\t1\t2' }); // eslint-disable-line prettier/prettier,max-len,indent,newline-per-chained-call


### PR DESCRIPTION
There are errors with jsonpath in OpenShift 4 and OC CLI >v4.5. I'm not entirely sure why and when this happens, as most times it works. But for cases where it fails,
it fails consistently. We ran into this issue when the OC version in the GitHub Actions Ubuntu image was updated to version 4.6.6. Our previously smooth running pipeline started to break our PR deployment.

The error shown is:

```
  error: error executing jsonpath "{range .items[*]}{@.kind}:{@.metadata.name} {end}": Error executing template: not in range, nothing to end. Printing more information for debugging the template:
	template was:
		{range .items[*]}{@.kind}:{@.metadata.name} {end}
	object given to jsonpath engine was:
		map[string]interface {}{"apiVersion":"v1", "items":[]interface {}{}, "kind":"List", "metadata":map[string]interface {}{"resourceVersion":"", "selfLink":""}}

```
Googling revealed https://github.com/kubernetes/kubectl/issues/913, which sounds similar.

The Go template version succeeds in the cases where the jsonpath version fails.

This was tested for our PR, Dev, Test and Prod deployments.