### PR TITLE
Update OpenShiftClientResult.js

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
 
     strategy:
       matrix:
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
     - name: npm install, build, and test

--- a/lib/OpenShiftClientResult.js
+++ b/lib/OpenShiftClientResult.js
@@ -18,93 +18,241 @@
 
 'use strict';
 
-// const OpenShiftClient = require('./OpenShiftClient');
-const isEmpty = require('lodash.isempty');
-
 module.exports = class OpenShiftClientResult {
-  constructor(client) {
-    this.client = client;
+  constructor(proc) {
+    this.proc = proc;
+
+    this.stdOutHeaders = [];
+    this.stdOutValues = [];
   }
 
   /**
-   * parses the string output from an oc get object --watch command
-   * this function in particular returns the field names as identified from the initial
-   * output from ocp
+   * Parses a raw stdOut string into separate strings (1 per std out line), and removes any that are empty.
+   *
+   * Example stdOut:
+   *
+   * ```
+   *  'NAME                         REVISION   DESIRED   CURRENT   TRIGGERED BY\n' +
+   *  'name-api-dev-78   4          1         0         config,image(name-api:dev-1.0.0-78)\n'
+   * ```
+   *
+   * Example return:
+   *
+   * ```
+   *  [
+   *   'NAME                         REVISION   DESIRED   CURRENT   TRIGGERED BY',
+   *   'name-api-dev-78   4          1         0         config,image(name-api:dev-1.0.0-78)'
+   *  ]
+   * ```
+   *
+   * @param {string[]} stdOut
+   * @returns an array of non-empty strings
    */
-  static parseGetObjectFields(stdOut) {
-    const [fieldNames] = stdOut.split('\n');
+  _getStdOutRows(stdOut) {
+    if (!stdOut) {
+      return [];
+    }
 
-    const names = fieldNames.replace(/ {2,}/g, '|{}|').split('|{}|');
+    const rawRows = stdOut.split('\n');
 
-    return names.map(n => {
-      return n.toLowerCase().replace(/ +/g, '_');
-    });
+    return rawRows.map(item => item.trim()).filter(item => item);
   }
 
   /**
-   * parses the string output from an oc get object --watch command
-   * this function in particular returns the data values from subsequent returns from ocp
+   * Parses a string (presumed to be the first row of the expected std out) into an array of trimmed lowercase strings.
+   *
+   * Example stdOutString:
+   *
+   * ```
+   *  'NAME                         REVISION   DESIRED   CURRENT   TRIGGERED BY'
+   * ```
+   *
+   * Example return:
+   *
+   * ```
+   *  ['name', 'revision', 'desired', 'current', 'triggered_by']
+   * ```
+   *
+   * @param {string[]} stdOutString
+   * @returns an array of header row values
    */
-  static parseGetObjectValues(stdOut) {
-    const entries = stdOut
+  _parseHeaderStdOutString(stdOutString) {
+    if (!stdOutString) {
+      return [];
+    }
+
+    return stdOutString
+      .trim()
+      .replace(/ {2,}/g, '|{}|')
+      .split('|{}|')
+      .map(item => item.toLowerCase().replace(/ +/g, '_'));
+  }
+
+  /**
+   * Parses a string (presumed not to be the first row of the expected std out) into an array of trimmed strings.
+   *
+   * Example stdOutString:
+   *
+   * ```
+   *  'name-api-dev-78   4          1         0         config,image(name-api:dev-1.0.0-78)'
+   * ```
+   *
+   * Example return:
+   *
+   * ```
+   *  ['name-api-dev-78', '4', '1', '0', 'config,image(name-api:dev-1.0.0-78)']
+   * ```
+   *
+   * @param {string[]} stdOutString
+   * @returns an array of row values
+   */
+  _parseValueStdOutString(stdOutString) {
+    if (!stdOutString) {
+      return [];
+    }
+
+    return stdOutString
       .trim()
       .replace(/ {2,}/g, '|{}|')
       .split('|{}|');
-    return entries;
   }
 
   /**
-   * waits for a deployment from the oc get dc --wait command
-   * it will kill the process once the desired replicas and current replicas are equal
-   * @param {Process} proc the process command that was spawned for oc get blah
+   * Builds an object, where the object keys are the `stdOutHeaders` items, and the object values are the `stdOutValues`
+   * items.
    *
-   * usage:
-   * const proc = self.rawAsync('get', 'dc', {
-      selector: `app=${appName}`,
-      watch: 'true'
-     });
-
-     OpenshiftClientResult.waitForDeployment(proc);
-     // proc will kill when replicas match desired amount
-
-     proc.on('exit', () => do something here)
+   *
+   * ### Example:
+   *
+   * Example stdOutHeaders:
+   *
+   * ```
+   *  ['name', 'revision', 'desired', 'current', 'triggered_by']
+   * ```
+   *
+   * Example stdOutValues:
+   *
+   * ```
+   *  ['name-api-dev-78', '4', '1', '0', 'config,image(name-api:dev-1.0.0-78)']
+   * ```
+   *
+   * Example return:
+   *
+   * ```
+   *  {
+   *    name: 'name-api-dev-78',
+   *    revision: '4',
+   *    desired: '1',
+   *    current: '0',
+   *    triggered_by: 'config,image(name-api:dev-1.0.0-78)'
+   *  }
+   * ```
+   *
+   * @param {*} stdOutHeaders array of header values
+   * @param {*} stdOutValues array of values
+   * @returns an object, where the keys are the header values
    */
-  static waitForDeployment(proc) {
-    let deployment = {};
+  _buildStdOutObject(stdOutHeaders, stdOutValues) {
+    if (!stdOutHeaders || !stdOutHeaders.length || !stdOutValues || !stdOutValues.length) {
+      return {};
+    }
+
+    const stdOutObject = {};
+
+    stdOutHeaders.forEach((header, index) => {
+      stdOutObject[header] = stdOutValues[index];
+    });
+
+    return stdOutObject;
+  }
+
+  /**
+   * Parses the raw process std out data into an object.
+   *
+   * @param {string} stdOutData
+   * @returns {object}
+   */
+  _parseProcessStdOutDataIntoObject(stdOutData) {
+    let stdOut = stdOutData.toString();
+
+    const stdOutRows = this._getStdOutRows(stdOut);
+
+    if (!stdOutRows.length) {
+      return {};
+    }
+
+    if (!this.stdOutHeaders.length) {
+      // Processing the first non-empty std out message received, parse the first row as the header row
+      this.stdOutHeaders = this._parseHeaderStdOutString(stdOutRows[0]);
+
+      if (stdOutRows[1]) {
+        // If present, parse a subsequent std out value row
+        this.stdOutValues = this._parseValueStdOutString(stdOutRows[1]);
+      }
+    } else {
+      // Parse a subsequent std out value row
+      this.stdOutValues = this._parseValueStdOutString(stdOutRows[0]);
+    }
+
+    // If both header and value rows were parsed, combine into an object, where the header row values are the keys
+    return this._buildStdOutObject(this.stdOutHeaders, this.stdOutValues);
+  }
+
+  /**
+   * Determines if a deployment is complete based on the properties of the `stdOutObject`.
+   * A deployment is considered complete if the current # of replicas equals the desired # of replicas.
+   *
+   * @param {object} stdOutObject
+   * @returns {boolean} `true` if the process is complete, `false` otherwise.
+   */
+  _isDeploymentComplete(stdOutObject) {
+    // Object is still missing expected values
+    if (!stdOutObject || !stdOutObject.desired || !stdOutObject.current) {
+      return false;
+    }
+
+    if (stdOutObject.desired === stdOutObject.current) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Waits for a deployment from the oc get dc --wait command.
+   *
+   * It will kill the process once the desired replicas and current replicas are equal.
+   *
+   * Example:
+   *
+   * ```
+   *  const proc = self.rawAsync('get', 'dc', {
+   *   selector: `app=${appName}`,
+   *   watch: 'true'
+   *  });
+   *
+   *  const openShiftClientResult = new OpenShiftClientResult(proc);
+   *  openShiftClientResult.waitForDeployment();
+   *  // proc will kill when replicas match desired amount
+   *
+   *  proc.on('exit', () => do something here)
+   * ```
+   */
+  waitForDeployment() {
+    if (!this.proc) {
+      return;
+    }
+
     // eslint-disable-next-line no-console
     console.log(`WAITING FOR DEPLOYMENT:
-      if a deployment fails, it will not throw. 
+      If a deployment fails, it will not throw. 
       Ensure you are setting appropriate timeouts while using this implementation!
     `);
 
-    proc.stdout.on('data', data => {
-      let stdOut = data.toString();
-      if (isEmpty(deployment)) {
-        const keys = OpenShiftClientResult.parseGetObjectFields(stdOut);
-        deployment = keys.reduce((obj, key) => {
-          // eslint-disable-next-line no-param-reassign
-          obj[key] = '';
-          return obj;
-        }, {});
-
-        // we need reference to keys to assign deployment values later
-        // eslint-disable-next-line no-underscore-dangle
-        deployment._keys = keys;
-
-        // the first stdout instance contains fields and values and so we remove field names now
-        // eslint-disable-next-line no-unused-vars
-        const [names, entries] = stdOut.split('\n');
-        stdOut = entries;
-      }
-
-      const deployData = OpenShiftClientResult.parseGetObjectValues(stdOut);
-      deployData.forEach((d, index) => {
-        // eslint-disable-next-line no-underscore-dangle
-        deployment[deployment._keys[index]] = d;
-      });
-
-      if (deployment.desired === deployment.current && deployment.desired !== '') {
-        proc.kill('SIGTERM');
+    this.proc.stdout.on('data', data => {
+      // Kill the child process if the current # of replicas is equal to the desired # of replicas (job is complete)
+      if (this._isDeploymentComplete(this._parseProcessStdOutDataIntoObject(data))) {
+        this.proc.kill('SIGTERM');
       }
     });
   }

--- a/lib/OpenShiftClientX.js
+++ b/lib/OpenShiftClientX.js
@@ -596,7 +596,8 @@ class OpenShiftClientX extends OpenShiftClient {
 
     return new Promise(resolve => {
       if (existingDC.stdout !== newDCs.stdout) {
-        OpenShiftClientResult.waitForDeployment(proc);
+        const openShiftClientResult = new OpenShiftClientResult(proc);
+        openShiftClientResult.waitForDeployment();
       } else {
         proc.kill('SIGTERM');
       }

--- a/lib/OpenShiftResourceSelector.js
+++ b/lib/OpenShiftResourceSelector.js
@@ -20,13 +20,10 @@
 
 const isPlainObject = require('lodash.isplainobject');
 const isString = require('lodash.isstring');
-const OpenShiftClientResult = require('./OpenShiftClientResult');
 
 const { isArray } = Array;
 
-// const OpenShiftStaticSelector = require('./OpenShiftStaticSelector')
-
-module.exports = class OpenShiftResourceSelector extends OpenShiftClientResult {
+module.exports = class OpenShiftResourceSelector {
   /**
    * @param {string} type 'selector', 'narrow', 'freeze'
    * @param {*} kind
@@ -40,7 +37,7 @@ module.exports = class OpenShiftResourceSelector extends OpenShiftClientResult {
    * ("dc", { alabel: 'avalue' }) // Selects using label values
    */
   constructor(client, type, kindOrList, qualifier = undefined) {
-    super(client);
+    this.client = client;
     this.ids = undefined;
     this.kind = undefined;
     this.qualifier = undefined;

--- a/test/OpenShiftClientResult.test.js
+++ b/test/OpenShiftClientResult.test.js
@@ -1,0 +1,292 @@
+'use strict';
+
+const expect = require('expect');
+const OpenShiftClientResult = require('../lib/OpenShiftClientResult');
+
+describe('OpenShiftClientResult', () => {
+  const procStub = {};
+
+  describe('_getStdOutRows', () => {
+    describe('returns an empty array', () => {
+      it('when stdOut is undefined', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._getStdOutRows(undefined);
+        expect(result).toEqual([]);
+      });
+
+      it('when stdOut is null', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._getStdOutRows(null);
+        expect(result).toEqual([]);
+      });
+
+      it('when stdOut is empty', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._getStdOutRows('');
+        expect(result).toEqual([]);
+      });
+    });
+
+    describe('returns an array', () => {
+      it('when stdOut has 1 line', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._getStdOutRows('this is a line');
+        expect(result).toEqual(['this is a line']);
+      });
+
+      it('when stdOut has 2 lines', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._getStdOutRows('this is line 1\nthis is line 2');
+        expect(result).toEqual(['this is line 1', 'this is line 2']);
+      });
+
+      it('when stdOut has 3 lines', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._getStdOutRows(
+          'this is line 1\nthis is line 2\nthis is line 3',
+        );
+        expect(result).toEqual(['this is line 1', 'this is line 2', 'this is line 3']);
+      });
+
+      it('when stdOut has empty lines', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._getStdOutRows(
+          'this is line 1\n\n\n\n\nthis is line 3',
+        );
+        expect(result).toEqual(['this is line 1', 'this is line 3']);
+      });
+
+      it('when stdOut has extra whitespace lines', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._getStdOutRows(
+          '    this is line 1   \n\n    \n   \n\n   this is line 3    ',
+        );
+        expect(result).toEqual(['this is line 1', 'this is line 3']);
+      });
+    });
+  });
+
+  describe('_parseHeaderStdOutString', () => {
+    describe('returns an empty array', () => {
+      it('when stdOut is undefined', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._parseHeaderStdOutString(undefined);
+        expect(result).toEqual([]);
+      });
+
+      it('when stdOut is null', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._parseHeaderStdOutString(null);
+        expect(result).toEqual([]);
+      });
+
+      it('when stdOut is empty', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._parseHeaderStdOutString('');
+        expect(result).toEqual([]);
+      });
+    });
+
+    describe('returns an array', () => {
+      it('when stdOut has 3 headers of mixed case with extra whitespace and underscores', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._parseHeaderStdOutString(
+          '   HEADER1          header2    HEADER 3   Header_4   ',
+        );
+        expect(result).toEqual(['header1', 'header2', 'header_3', 'header_4']);
+      });
+    });
+  });
+
+  describe('_parseValueStdOutString', () => {
+    describe('returns an empty array', () => {
+      it('when stdOut is undefined', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._parseValueStdOutString(undefined);
+        expect(result).toEqual([]);
+      });
+
+      it('when stdOut is null', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._parseValueStdOutString(null);
+        expect(result).toEqual([]);
+      });
+
+      it('when stdOut is empty', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._parseValueStdOutString('');
+        expect(result).toEqual([]);
+      });
+    });
+
+    describe('returns an array', () => {
+      it('when stdOut is a string with extra whitespace', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._parseValueStdOutString('    this is a line    ');
+        expect(result).toEqual(['this is a line']);
+      });
+    });
+  });
+
+  describe('_buildStdOutObject', () => {
+    describe('returns an empty object', () => {
+      it('when stdOutHeaders is undefined', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._buildStdOutObject(undefined, ['valid']);
+        expect(result).toEqual({});
+      });
+
+      it('when stdOutHeaders is null', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._buildStdOutObject(null, ['valid']);
+        expect(result).toEqual({});
+      });
+
+      it('when stdOutHeaders length is 0', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._buildStdOutObject([], ['valid']);
+        expect(result).toEqual({});
+      });
+
+      it('when stdOutValues is undefined', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._buildStdOutObject(['valid'], undefined);
+        expect(result).toEqual({});
+      });
+
+      it('when stdOutValues is null', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._buildStdOutObject(['valid'], null);
+        expect(result).toEqual({});
+      });
+
+      it('when stdOutValues length is 0', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._buildStdOutObject(['valid'], []);
+        expect(result).toEqual({});
+      });
+    });
+
+    describe('returns an object', () => {
+      it('when stdOutHeaders and stdOutValues are valid and the same length', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._buildStdOutObject(
+          ['header1', 'header2'],
+          ['value1', 'value2'],
+        );
+        expect(result).toEqual({ header1: 'value1', header2: 'value2' });
+      });
+
+      it('when stdOutHeaders and stdOutValues are valid but stdOutHeaders has extra items', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._buildStdOutObject(
+          ['header1', 'header2', 'header3'],
+          ['value1', 'value2'],
+        );
+        expect(result).toEqual({ header1: 'value1', header2: 'value2', header3: undefined });
+      });
+
+      it('when stdOutHeaders and stdOutValues are valid but stdOutValues has extra items', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._buildStdOutObject(
+          ['header1', 'header2'],
+          ['value1', 'value2'],
+        );
+        expect(result).toEqual({ header1: 'value1', header2: 'value2' });
+      });
+    });
+  });
+
+  describe('_parseProcessStdOutDataIntoObject', () => {
+    it('when stdOut is empty', () => {
+      const openShiftClientResult = new OpenShiftClientResult(procStub);
+      const result = openShiftClientResult._parseProcessStdOutDataIntoObject('');
+      expect(result).toEqual({});
+    });
+
+    it('when stdOut has 1 line initially', () => {
+      const openShiftClientResult = new OpenShiftClientResult(procStub);
+      const result1 = openShiftClientResult._parseProcessStdOutDataIntoObject(
+        'header1  header2  header3\n',
+      );
+      expect(result1).toEqual({});
+
+      const result2 = openShiftClientResult._parseProcessStdOutDataIntoObject(
+        'value1  value2  value3\n',
+      );
+      expect(result2).toEqual({ header1: 'value1', header2: 'value2', header3: 'value3' });
+    });
+
+    it('when stdOut has 2 lines initially', () => {
+      const openShiftClientResult = new OpenShiftClientResult(procStub);
+      const result = openShiftClientResult._parseProcessStdOutDataIntoObject(
+        'header1  header2  header3\nvalue1  value2  value3',
+      );
+      expect(result).toEqual({ header1: 'value1', header2: 'value2', header3: 'value3' });
+    });
+
+    it('when stdOut has 1 line initially and receives empty subsequent lines', () => {
+      const openShiftClientResult = new OpenShiftClientResult(procStub);
+      const result1 = openShiftClientResult._parseProcessStdOutDataIntoObject(
+        'header1  header2  header3\n',
+      );
+      expect(result1).toEqual({});
+
+      const result2 = openShiftClientResult._parseProcessStdOutDataIntoObject('\n      \n   \n');
+      expect(result2).toEqual({});
+
+      const result3 = openShiftClientResult._parseProcessStdOutDataIntoObject(
+        'value1  value2  value3\n',
+      );
+      expect(result3).toEqual({ header1: 'value1', header2: 'value2', header3: 'value3' });
+    });
+  });
+
+  describe('_isDeploymentComplete', () => {
+    describe('returns false', () => {
+      it('when stdOutObject is undefined', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._isDeploymentComplete(undefined);
+        expect(result).toEqual(false);
+      });
+
+      it('when stdOutObject is null', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._isDeploymentComplete(null);
+        expect(result).toEqual(false);
+      });
+
+      it('when stdOutObject is empty', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._isDeploymentComplete({});
+        expect(result).toEqual(false);
+      });
+
+      it('is missing `desired` property', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._isDeploymentComplete({ current: 1 });
+        expect(result).toEqual(false);
+      });
+
+      it('is missing `current` property', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._isDeploymentComplete({ desired: 1 });
+        expect(result).toEqual(false);
+      });
+
+      it('`desired` and `current` properties do not match', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._isDeploymentComplete({ current: 0, desired: 1 });
+        expect(result).toEqual(false);
+      });
+    });
+
+    describe('returns true', () => {
+      it('`desired` and `current` properties match', () => {
+        const openShiftClientResult = new OpenShiftClientResult(procStub);
+        const result = openShiftClientResult._isDeploymentComplete({ current: 1, desired: 1 });
+        expect(result).toEqual(true);
+      });
+    });
+  });
+});


### PR DESCRIPTION
(Not sure if this PR should be against master? Or another branch?)

The previous implementation would sometimes fail due to calling `.trim()` on an undefined item ([example log](https://github.com/bcgov/biohubbc-platform/runs/7206267591?check_suite_focus=true))
This would then fail the Git Action it was running under.

- Updated `OpenShiftClientResult.js` to include more null checks, and to be easier to read.
  - Added lots of comments/examples as the purpose of the parsing isn't super obvious.
  - Added unit tests.
- Updated `OpenShiftResourceSelector` to no longer extend `OpenShiftClientResult` as it was never being used.

- Bumped git workflow versions
  - Ubuntu 16 is apparently not supported, which is why the workflow in previous runs never got picked up

Tested that it works as expected by running our projects current git workflow, using this new version of pipeline-cli from this PR (via my fork). https://github.com/bcgov/biohubbc-platform/actions/runs/2707812646
